### PR TITLE
fix source map file path when use `fis3-hook-relative` plugin & add `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/index.js
+++ b/index.js
@@ -10,90 +10,90 @@ var util = require('util');
 var mergeMap = require('merge-source-map');
 
 function uglify(content, file, conf) {
-    conf.fromString = true;
+  conf.fromString = true;
 
-    if (conf.sourceMap) {
-        var mapping = fis.file.wrap(file.dirname + '/' + file.filename + file.rExt + '.map');
-        conf.outSourceMap = mapping.subpath;
+  if (conf.sourceMap) {
+    var mapping = fis.file.wrap(file.dirname + '/' + file.filename + file.rExt + '.map');
+    conf.outSourceMap = mapping.subpath;
+  }
+
+  var ret = UglifyJS.minify(content, conf);
+
+  if (conf.sourceMap) {
+    var mapData = JSON.parse(ret.map);
+
+    mapData.sources = [file.subpath];
+    mapData.sourcesContent = [content];
+
+    var newData = {
+      version: mapData.version,
+      file: getRelativeUrl(mapData.file, file),
+      sources: mapData.sources.map(function (target) {
+        return getRelativeUrl(target, file);
+      }),
+      sourcesContent: mapData.sourcesContent,
+      names: mapData.names,
+      mappings: mapData.mappings
+    };
+
+
+    var originMapFile = getMapFile(file);
+    if (originMapFile) {
+      file.extras.derived.shift();
+      var merged = mergeMap(JSON.parse(originMapFile.getContent()), newData);
+      mapping.setContent(JSON.stringify(merged));
+    } else {
+      mapping.setContent(JSON.stringify(newData));
     }
 
-    var ret = UglifyJS.minify(content, conf);
+    file.extras = file.extras || {};
+    file.extras.derived = file.extras.derived || [];
+    file.extras.derived.push(mapping);
 
-    if (conf.sourceMap) {
-        var mapData = JSON.parse(ret.map);
+    // 先删掉原始的 sourceMappingURL
+    var url;
+    ret.code = ret.code.replace(/\n?\s*\/\/#\ssourceMappingURL=.*?(?:\n|$)/g, '');
+    url = mapping.getUrl(fis.compile.settings.hash, fis.compile.settings.domain);
+    url = getRelativeUrl(url, file);
+    ret.code += '\n//# sourceMappingURL=' + url + '\n';
+  }
 
-        mapData.sources = [file.subpath];
-        mapData.sourcesContent = [content];
-
-        var newData = {
-            version: mapData.version,
-            file: getRelativeUrl(mapData.file, file),
-            sources: mapData.sources.map(function (target) {
-                return getRelativeUrl(target, file);
-            }),
-            sourcesContent: mapData.sourcesContent,
-            names: mapData.names,
-            mappings: mapData.mappings
-        };
-
-
-        var originMapFile = getMapFile(file);
-        if (originMapFile) {
-            file.extras.derived.shift();
-            var merged = mergeMap(JSON.parse(originMapFile.getContent()), newData);
-            mapping.setContent(JSON.stringify(merged));
-        } else {
-            mapping.setContent(JSON.stringify(newData));
-        }
-
-        file.extras = file.extras || {};
-        file.extras.derived = file.extras.derived || [];
-        file.extras.derived.push(mapping);
-
-        // 先删掉原始的 sourceMappingURL
-        var url;
-        ret.code = ret.code.replace(/\n?\s*\/\/#\ssourceMappingURL=.*?(?:\n|$)/g, '');
-        url = mapping.getUrl(fis.compile.settings.hash, fis.compile.settings.domain);
-        url = getRelativeUrl(url, file);
-        ret.code += '\n//# sourceMappingURL=' + url + '\n';
-    }
-
-    return ret.code;
+  return ret.code;
 }
 
 module.exports = function (content, file, conf) {
 
-    try {
-        content = uglify(content, file, conf);
-    } catch (e) {
-        fis.log.warning(util.format('Got Error %s while uglify %s', e.message, file.subpath));
-        fis.log.debug(e.stack);
-    }
+  try {
+    content = uglify(content, file, conf);
+  } catch (e) {
+    fis.log.warning(util.format('Got Error %s while uglify %s', e.message, file.subpath));
+    fis.log.debug(e.stack);
+  }
 
-    return content;
+  return content;
 };
 
 function getRelativeUrl(target, file) {
-    var msg = {
-        target: target,
-        file: file,
-        ret: target && target.url || target
-    };
-    if (file.relative) {
-        fis.emit('plugin:relative:fetch', msg);
-    }
-    return msg.ret;
+  var msg = {
+    target: target,
+    file: file,
+    ret: target && target.url || target
+  };
+  if (file.relative) {
+    fis.emit('plugin:relative:fetch', msg);
+  }
+  return msg.ret;
 }
 
 function getMapFile(file) {
-    var derived = file.derived;
-    if (!derived || !derived.length) {
-        derived = file.extras && file.extras.derived;
-    }
+  var derived = file.derived;
+  if (!derived || !derived.length) {
+    derived = file.extras && file.extras.derived;
+  }
 
-    if (derived && derived[0] && derived[0].rExt === '.map') {
-        return derived[0];
-    }
+  if (derived && derived[0] && derived[0].rExt === '.map') {
+    return derived[0];
+  }
 
-    return null;
+  return null;
 }

--- a/index.js
+++ b/index.js
@@ -10,73 +10,90 @@ var util = require('util');
 var mergeMap = require('merge-source-map');
 
 function uglify(content, file, conf) {
-  conf.fromString = true;
+    conf.fromString = true;
 
-  if (conf.sourceMap) {
-      var mapping = fis.file.wrap(file.dirname + '/' + file.filename + file.rExt + '.map');
-      conf.outSourceMap = mapping.subpath;
-  }
+    if (conf.sourceMap) {
+        var mapping = fis.file.wrap(file.dirname + '/' + file.filename + file.rExt + '.map');
+        conf.outSourceMap = mapping.subpath;
+    }
 
-  var ret = UglifyJS.minify(content, conf);
+    var ret = UglifyJS.minify(content, conf);
 
-  if (conf.sourceMap) {
-      var mapData = JSON.parse(ret.map);
+    if (conf.sourceMap) {
+        var mapData = JSON.parse(ret.map);
 
-      mapData.sources = [file.subpath];
-      mapData.sourcesContent = [content];
+        mapData.sources = [file.subpath];
+        mapData.sourcesContent = [content];
 
-      var newData = {
-          version: mapData.version,
-          file: mapData.file,
-          sources: mapData.sources,
-          sourcesContent: mapData.sourcesContent,
-          names: mapData.names,
-          mappings: mapData.mappings
-      };
+        var newData = {
+            version: mapData.version,
+            file: getRelativeUrl(mapData.file, file),
+            sources: mapData.sources.map(function (target) {
+                return getRelativeUrl(target, file);
+            }),
+            sourcesContent: mapData.sourcesContent,
+            names: mapData.names,
+            mappings: mapData.mappings
+        };
 
 
-      var originMapFile = getMapFile(file);
-      if (originMapFile) {
-        file.extras.derived.shift();
-        var merged = mergeMap(JSON.parse(originMapFile.getContent()), newData);
-        mapping.setContent(JSON.stringify(merged));
-      } else {
-        mapping.setContent(JSON.stringify(newData));
-      }
+        var originMapFile = getMapFile(file);
+        if (originMapFile) {
+            file.extras.derived.shift();
+            var merged = mergeMap(JSON.parse(originMapFile.getContent()), newData);
+            mapping.setContent(JSON.stringify(merged));
+        } else {
+            mapping.setContent(JSON.stringify(newData));
+        }
 
-      file.extras = file.extras || {};
-      file.extras.derived = file.extras.derived || [];
-      file.extras.derived.push(mapping);
+        file.extras = file.extras || {};
+        file.extras.derived = file.extras.derived || [];
+        file.extras.derived.push(mapping);
 
-      // 先删掉原始的 sourceMappingURL
-      ret.code = ret.code.replace(/\n?\s*\/\/#\ssourceMappingURL=.*?(?:\n|$)/g, '');
-      ret.code += '\n//# sourceMappingURL=' + mapping.getUrl(fis.compile.settings.hash, fis.compile.settings.domain) + '\n';
-  }
+        // 先删掉原始的 sourceMappingURL
+        var url;
+        ret.code = ret.code.replace(/\n?\s*\/\/#\ssourceMappingURL=.*?(?:\n|$)/g, '');
+        url = mapping.getUrl(fis.compile.settings.hash, fis.compile.settings.domain);
+        url = getRelativeUrl(url, file);
+        ret.code += '\n//# sourceMappingURL=' + url + '\n';
+    }
 
-  return ret.code;
+    return ret.code;
 }
 
-module.exports = function(content, file, conf){
+module.exports = function (content, file, conf) {
 
-  try {
-    content = uglify(content, file, conf);
-  } catch (e) {
-    fis.log.warning(util.format('Got Error %s while uglify %s', e.message, file.subpath));
-    fis.log.debug(e.stack);
-  }
+    try {
+        content = uglify(content, file, conf);
+    } catch (e) {
+        fis.log.warning(util.format('Got Error %s while uglify %s', e.message, file.subpath));
+        fis.log.debug(e.stack);
+    }
 
-  return content;
+    return content;
 };
 
+function getRelativeUrl(target, file) {
+    var msg = {
+        target: target,
+        file: file,
+        ret: target && target.url || target
+    };
+    if (file.relative) {
+        fis.emit('plugin:relative:fetch', msg);
+    }
+    return msg.ret;
+}
+
 function getMapFile(file) {
-  var derived = file.derived;
-  if (!derived || !derived.length) {
-    derived = file.extras && file.extras.derived;
-  }
+    var derived = file.derived;
+    if (!derived || !derived.length) {
+        derived = file.extras && file.extras.derived;
+    }
 
-  if (derived && derived[0] && derived[0].rExt === '.map') {
-    return derived[0];
-  }
+    if (derived && derived[0] && derived[0].rExt === '.map') {
+        return derived[0];
+    }
 
-  return null;
+    return null;
 }


### PR DESCRIPTION
When use relative path, the source map file path still be absolute path, this led to source map not work.

So, this PR added support of relative path.

Additionally, added `.editorconfig` file to consistent coding styles.