### PR TITLE
feat: 遍历 derived 查找 .map 文件

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,8 @@ function uglify(content, file, conf) {
       };
 
 
-      var originMapFile = getMapFile(file);
+      var originMapFile = popMapFile(file);
       if (originMapFile) {
-        file.extras.derived.shift();
         var merged = mergeMap(JSON.parse(originMapFile.getContent()), newData);
         mapping.setContent(JSON.stringify(merged));
       } else {
@@ -68,14 +67,23 @@ module.exports = function(content, file, conf){
   return content;
 };
 
-function getMapFile(file) {
+function popMapFile(file) {
   var derived = file.derived;
-  if (!derived || !derived.length) {
-    derived = file.extras && file.extras.derived;
-  }
+  var extraDerived = file.extras && file.extras.derived;
 
-  if (derived && derived[0] && derived[0].rExt === '.map') {
-    return derived[0];
+  return popMapFromArray(derived) || popMapFromArray(extraDerived);
+}
+
+function popMapFromArray(derived) {
+  if (!Array.isArray(derived)) {
+    return null;
+  }
+  var index = derived.findIndex(function (ele) {
+    return ele.rExt === '.map';
+  });
+
+  if (index > -1) {
+    return derived.splice(index, 1)[0];
   }
 
   return null;


### PR DESCRIPTION
## 修改前：
getMapFile 函数会优先从 `file.derived` 中查找，`file.derived` 不存在时再去 `file.extras.derived` 中查找。
只会取第一个文件。
找到 originMapFile 后，会执行 `file.extras.derived.shift()`。

## 问题：

`file.derived` 可能存在有文件，但 originMapFile 在`file.extras.derived` 中，造成查找不到。
如果将 originMapFile 放在 `file.derived`，则必须放在第一个，否则找不到。
且由于此时 `file.extras.derived` 不存在，执行 `file.extras.derived.shift()` 会报错，且不会正确删除 originMapFile。

## 修改后：

查找优先级：`file.derived`  > `file.extras.derived`。
找到后的行为：返回该 `originMapFile` 文件，从原 derived 中删除 `originMapFile`。

