### PR TITLE
升级uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "merge-source-map": "1.0.1",
-    "uglify-js": "2.4.15"
+    "uglify-js": "2.8.29"
   }
 }


### PR DESCRIPTION
低版本uglify-js进行压缩混淆时有概率（可能发生在文件过大时，具体原因待查）会使promise失效，导致压缩后的代码执行过程中调不到then和catch语句块，经测2.8.29版本已修复